### PR TITLE
Update to Kotlin v1.0.1, fixes Gradle build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile 'com.squareup.picasso:picasso:2.5.2'
 }
 buildscript {
-    ext.kotlin_version = '1.0.0'
+    ext.kotlin_version = '1.0.1'
     repositories {
         mavenCentral()
     }


### PR DESCRIPTION
At least on my system your project isn't able to complete the Gradle configuration. It appears to be an issue in Kotlin v1.0.0 and is fixed in v1.0.1.
